### PR TITLE
Fix 11 flaky tests by using LinkedHashMap

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -37,7 +37,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +86,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +129,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
Use LinkedHashMaps instead of HashMaps in AuthenticationToken class to fix 11 flaky tests.

### Flaky Tests list

```
com.eatthepath.pushy.apns.auth.AuthenticationTokenTest#testVerifySignature
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithCollapseId
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithExpirationDate
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithMissingPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithValidNotification
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotification
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotificationWithPushTypeHeader
```

### Problem

There are 11 tests identified as flaky in 3 different test classes due to the nondeterministic iterative order of HashMap elements in AuthenticationToken class. These tests are identified using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. All these tests failed for different reasons, but the underlying root cause is the same.

### Root cause

verifySignature() method in AuthenticationToken class verifies the cryptographic signature of the authentication token.  During the execution, two HashMaps are converted to strings using JsonSerializer.writeJsonTextAsString() function here

https://github.com/bbelide2/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L278-L279

These strings are ```headerJson``` and ```claimsJson``` which are generated by converting HashMaps to strings. These HashMaps are built by the ```toMap()``` methods in ```AuthenticationTokenHeader``` and ```AuthenticationTokenClaims``` subclasses.  As HashMaps do not preserve the order of elements, different map objects (different element order) are generated in different tests thus resulting in different ```headerJson``` and ```claimsJson``` each time. This results in different boolean responses of the verifySignature() method. The verification fails when it is expected to pass. 

All the 11 identified tests trigger this method and therefore have a flaky behavior.

### Sample Test

Test: 
[com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload](https://github.com/bbelide2/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java#L249-L267)

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl pushy -am -DskipTests
```

2) **Regular test** - Successful
Command used - 
```
mvn -pl pushy test -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
```

3) **NonDex test** - Failed
Command used - 
```
mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
```


**NonDex test error:**

```
[ERROR] Failures: 
[ERROR]   TokenAuthenticationValidatingPushNotificationHandlerTest>ValidatingPushNotificationHandlerTest.testHandleNotificationWithOversizedPayload:259->ValidatingPushNotificationHandlerTest.assertNotificationRejected:273 Push notifications with a device token for the wrong topic should be rejected. ==> expected: <PAYLOAD_TOO_LARGE> but was: <INVALID_PROVIDER_TOKEN>
```

The test case failed because the expected rejection reason  is **"PAYLOAD_TOO_LARGE"** but the actual rejection reason is **"INVALID_PROVIDER_TOKEN"**. This is because "INVALID_PROVIDER_TOKEN" error is thrown at this point: 

https://github.com/bbelide2/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java#L92-L94 

 This is because signature verification failed here: 

https://github.com/bbelide2/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L293

The signature verification failed because verifySignature() function returned false instead of true.

### Fix

This problem is fixed by using LinkedHashMap instead of HashMap to keep the order deterministic. All the 11 tests passed after the fix.